### PR TITLE
Drop support for old Mupen, add new Mupen support

### DIFF
--- a/StarManager/MainWindow.cs
+++ b/StarManager/MainWindow.cs
@@ -164,14 +164,15 @@ namespace StarDisplay
 
         static string[] processNames = { 
             "project64", "project64d",
-            "mupen64-rerecording",
-            "mupen64-pucrash",
-            "mupen64_lua",
-            "mupen64-wiivc",
-            "mupen64-RTZ",
-            "mupen64-rerecording-v2-reset",
-            "mupen64-rrv8-avisplit",
-            "mupen64-rerecording-v2-reset",
+            //"mupen64-rerecording",
+            //"mupen64-pucrash",
+            //"mupen64_lua",
+            //"mupen64-wiivc",
+            //"mupen64-RTZ",
+            //"mupen64-rerecording-v2-reset",
+            //"mupen64-rrv8-avisplit",
+            //"mupen64-rerecording-v2-reset",
+            "mupen64",
             // "retroarch" 
         };
 

--- a/StarManager/Managers/MemoryManager.cs
+++ b/StarManager/Managers/MemoryManager.cs
@@ -201,7 +201,9 @@ namespace StarDisplay
                     //{ "mupen64-RTZ", 0x00901920 },
                     //{ "mupen64-rrv8-avisplit", 0x008ECBB0 },
                     //{ "mupen64-rerecording-v2-reset", 0x008ECA90 },
-                    { "mupen64", 0x00505CB0 }, // 1.0.9
+                    //{ "mupen64", 0x00505CB0 }, // 1.0.9
+                    //{ "mupen64", 0x00505D80 }, // 1.0.9.1
+                    { "mupen64", 0x0050B110 }, // 1.0.10
                 };
 
                 ramPtrBaseSuggestions.Add(mupenRAMSuggestions[name]);

--- a/StarManager/Managers/MemoryManager.cs
+++ b/StarManager/Managers/MemoryManager.cs
@@ -197,11 +197,12 @@ namespace StarDisplay
                     //{ "mupen64-rerecording", 0x008EBA80 },
                     //{ "mupen64-pucrash", 0x00912300 },
                     //{ "mupen64_lua", 0x00888F60 },
-                    //{ "mupen64-wiivc", 0x00901920 },
+                    //{ "mupen64-wiivc", 0x00901920 },              // old mupen releases
                     //{ "mupen64-RTZ", 0x00901920 },
                     //{ "mupen64-rrv8-avisplit", 0x008ECBB0 },
                     //{ "mupen64-rerecording-v2-reset", 0x008ECA90 },
-                    { "mupen64", 0x00505CB0 },
+                    { "mupen64", 0x004FC700 }, // 1.0.8
+                    { "mupen64", 0x00505CB0 }, // 1.0.9
                 };
 
                 ramPtrBaseSuggestions.Add(mupenRAMSuggestions[name]);

--- a/StarManager/Managers/MemoryManager.cs
+++ b/StarManager/Managers/MemoryManager.cs
@@ -201,7 +201,6 @@ namespace StarDisplay
                     //{ "mupen64-RTZ", 0x00901920 },
                     //{ "mupen64-rrv8-avisplit", 0x008ECBB0 },
                     //{ "mupen64-rerecording-v2-reset", 0x008ECA90 },
-                    { "mupen64", 0x004FC700 }, // 1.0.8
                     { "mupen64", 0x00505CB0 }, // 1.0.9
                 };
 

--- a/StarManager/Managers/MemoryManager.cs
+++ b/StarManager/Managers/MemoryManager.cs
@@ -194,13 +194,14 @@ namespace StarDisplay
             {
                 Dictionary<string, int> mupenRAMSuggestions = new Dictionary<string, int>
                 {
-                    { "mupen64-rerecording", 0x008EBA80 },
-                    { "mupen64-pucrash", 0x00912300 },
-                    { "mupen64_lua", 0x00888F60 },
-                    { "mupen64-wiivc", 0x00901920 },
-                    { "mupen64-RTZ", 0x00901920 },
-                    { "mupen64-rrv8-avisplit", 0x008ECBB0 },
-                    { "mupen64-rerecording-v2-reset", 0x008ECA90 },
+                    //{ "mupen64-rerecording", 0x008EBA80 },
+                    //{ "mupen64-pucrash", 0x00912300 },
+                    //{ "mupen64_lua", 0x00888F60 },
+                    //{ "mupen64-wiivc", 0x00901920 },
+                    //{ "mupen64-RTZ", 0x00901920 },
+                    //{ "mupen64-rrv8-avisplit", 0x008ECBB0 },
+                    //{ "mupen64-rerecording-v2-reset", 0x008ECA90 },
+                    { "mupen64", 0x00505CB0 },
                 };
 
                 ramPtrBaseSuggestions.Add(mupenRAMSuggestions[name]);
@@ -210,13 +211,14 @@ namespace StarDisplay
             {
                 { "Project64", 0 },
                 { "Project64d", 0 },
-                { "mupen64-rerecording", 0x20 },
-                { "mupen64-pucrash", 0x20 },
-                { "mupen64_lua", 0x20 },
-                { "mupen64-wiivc", 0x20 },
-                { "mupen64-RTZ", 0x20 },
-                { "mupen64-rrv8-avisplit", 0x20 },
-                { "mupen64-rerecording-v2-reset", 0x20 },
+                //{ "mupen64-rerecording", 0x20 },
+                //{ "mupen64-pucrash", 0x20 },
+                //{ "mupen64_lua", 0x20 },
+                //{ "mupen64-wiivc", 0x20 },
+                //{ "mupen64-RTZ", 0x20 },
+                //{ "mupen64-rrv8-avisplit", 0x20 },
+                //{ "mupen64-rerecording-v2-reset", 0x20 },
+                { "mupen64", 0x20 },
                 { "retroarch", 0x40 },
             };
 


### PR DESCRIPTION
Most people using Mupen for tasing are now using the newer releases. This PR just disables compatibility with old Mupen releases, and adds it for version 1.0.9. As new versions are released, there may need to be updates to this code to maintain compatibility.